### PR TITLE
Add where option and format changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,44 +6,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Unreleased
+==========
+### Added
+- Add `where` option to `all` function
+### Changed
+
+### Removed
+
+### Fixed
+
+### Security
+
+---
+
 [1.3.3]
+-------
 ### Fixed
 - Incorrect functions generated when providing both `suffix: false` and other  options to the `resource` macro
 
+---
+
 [1.3.2]
-------------
+-------
 ### Fixed
 - Incorrect function name generation when providing both `suffix: false` and other options to the `resource` macro
 
+---
+
 [1.3.1]
-------------
-
-### Added
-
+-------
 ### Changed
 - Allow keyword lists where currently only maps are supported
-
-### Removed
 
 ### Fixed
 - Fixed some bad tests to have better assertions
 
-### Security
-
+---
 
 [1.3.0]
-------------
-
+-------
 ### Added
 - `changeset` convenience function added
 
-### Changed
-
-### Removed
-
-### Fixed
-
-### Security
+---
 
 [1.2.0] - 2019-09-17
 --------------------

--- a/lib/resource_functions.ex
+++ b/lib/resource_functions.ex
@@ -108,10 +108,12 @@ defmodule EctoCooler.ResourceFunctions do
   def all(repo, schema, options \\ []) do
     preloads = Keyword.get(options, :preloads, [])
     order_by = Keyword.get(options, :order_by, [])
+    where = Keyword.get(options, :where, [])
 
     schema
     |> preload(^preloads)
     |> order_by(^order_by)
+    |> where(^where)
     |> repo.all([])
   end
 

--- a/test/ecto_cooler/defaults_test.exs
+++ b/test/ecto_cooler/defaults_test.exs
@@ -39,6 +39,15 @@ defmodule EctoCooler.DefaultsTest do
       assert length(result) == 1
       assert first_person.first_name == person.first_name
     end
+
+    test "it filters based on 'where' option " do
+      person = struct(Person, @person_attributes)
+      Repo.insert(person)
+      result = People.all_people(where: [age: 40])
+      assert [] == result
+      result = People.all_people(where: [age: 42])
+      assert length(result) == 1
+    end
   end
 
   describe "change" do


### PR DESCRIPTION
Taken from https://github.com/joseph-lozano/ecto_resource/tree/where_opt since this is the maintained version of ecto_resource.