### PR TITLE
fix: Manually do semantic versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # fetch tags and history for git_ops
+          fetch-depth: 0 # fetch tags and history for git operations
 
       - name: Set up Elixir & OTP
         uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.18" # adjust as needed
+          elixir-version: "1.18"
           otp-version: "27"
 
       - name: Install dependencies
@@ -46,16 +46,65 @@ jobs:
       - name: Run tests
         run: mix test
 
-      - name: Run git_ops release (auto-version)
-        id: git_ops
+      - name: Determine version bump from branch name
+        id: version_bump
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          
+          if [[ "$BRANCH_NAME" =~ ^(major|breaking)/ ]]; then
+            echo "bump_type=major" >> $GITHUB_OUTPUT
+            echo "bump_reason=major/breaking change" >> $GITHUB_OUTPUT
+          elif [[ "$BRANCH_NAME" =~ ^(minor|feature)/ ]]; then
+            echo "bump_type=minor" >> $GITHUB_OUTPUT
+            echo "bump_reason=minor/feature addition" >> $GITHUB_OUTPUT
+          elif [[ "$BRANCH_NAME" =~ ^(patch|fix|bugfix|hotfix)/ ]]; then
+            echo "bump_type=patch" >> $GITHUB_OUTPUT
+            echo "bump_reason=patch/bug fix" >> $GITHUB_OUTPUT
+          else
+            echo "bump_type=none" >> $GITHUB_OUTPUT
+            echo "bump_reason=no conventional commit prefix found" >> $GITHUB_OUTPUT
+          fi
+          
+          echo "Branch: $BRANCH_NAME"
+          echo "Bump type: ${{ steps.version_bump.outputs.bump_type }}"
+          echo "Reason: ${{ steps.version_bump.outputs.bump_reason }}"
+
+      - name: Bump version and update changelog
+        if: steps.version_bump.outputs.bump_type != 'none'
+        id: version_update
         env:
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
           GIT_AUTHOR_NAME: github-actions[bot]
           GIT_AUTHOR_EMAIL: github-actions[bot]@users.noreply.github.com
         run: |
-          mix git_ops.release --yes || echo "No version bump needed"
+          chmod +x scripts/bump_version.sh
+          OUTPUT=$(./scripts/bump_version.sh "${{ steps.version_bump.outputs.bump_type }}" "${{ github.event.pull_request.head.ref }}" "${{ github.event.pull_request.title }}")
+          
+          # Parse the output to get version info
+          NEW_VERSION=$(echo "$OUTPUT" | grep "new_version=" | cut -d'=' -f2)
+          OLD_VERSION=$(echo "$OUTPUT" | grep "old_version=" | cut -d'=' -f2)
+          
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "old_version=$OLD_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Push commits & tags
+      - name: Commit and tag release
+        if: steps.version_bump.outputs.bump_type != 'none'
         run: |
-          git push origin HEAD:main --follow-tags 
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          git add mix.exs CHANGELOG.md
+          git commit -m "Release version ${{ steps.version_update.outputs.new_version }}"
+          
+          git tag -a "v${{ steps.version_update.outputs.new_version }}" \
+            -m "Release version ${{ steps.version_update.outputs.new_version }}"
+          
+          git push origin HEAD:main --follow-tags
+
+      - name: Skip release
+        if: steps.version_bump.outputs.bump_type == 'none'
+        run: |
+          echo "No conventional commit prefix found in branch name. Skipping release."
+          echo "Branch name: ${{ github.event.pull_request.head.ref }}"
+          echo "Expected prefixes: major/, minor/, patch/, fix/, bugfix/, hotfix/, feature/"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@
 - [Contribution](#contribution)
   - [Bug reports](#bug_reports)
   - [Pull requests](#pull_requests)
+- [Release Workflow](#release-workflow)
+  - [Branch Naming Convention](#branch-naming-convention)
+  - [What Happens on Merge](#what-happens-on-merge)
+  - [Skipping Releases](#skipping-releases)
+  - [Manual Releases](#manual-releases)
 - [License](#license)
 - [Authors](#authors)
 
@@ -515,6 +520,49 @@ If you discover any bugs, feel free to create an issue on [GitHub](https://githu
 ### Nice to have features/improvements (:point_up::wink:)
 
 - Ability to override pluralization
+
+## Release Workflow
+
+This project uses a conventional commit-based release workflow that automatically creates releases when pull requests are merged to the main branch.
+
+### Branch Naming Convention
+
+To trigger a release, your branch name must follow the conventional commit format:
+
+- **Major version bump**: `major/description` or `breaking/description`
+  - Example: `major/breaking-api-changes`
+- **Minor version bump**: `minor/description` or `feature/description`
+  - Example: `feature/add-new-generator`
+- **Patch version bump**: `patch/description`, `fix/description`, `bugfix/description`, or `hotfix/description`
+  - Example: `fix/resolve-version-parsing-issue`
+
+### What Happens on Merge
+
+When a pull request with a conventional commit branch name is merged to main:
+
+1. **Version Detection**: The workflow analyzes the branch name to determine the version bump type
+2. **Version Update**: Updates the version in `mix.exs` according to semantic versioning
+3. **Changelog Update**: 
+   - Creates a new version entry in `CHANGELOG.md`
+   - Adds the PR title to the appropriate section (Added/Changed/Fixed)
+4. **Release Tag**: Creates and pushes a git tag with the new version
+5. **Commit**: Commits the version and changelog changes to main
+
+### Skipping Releases
+
+If your branch doesn't follow the conventional commit naming pattern, no release will be created. This is useful for:
+- Documentation updates
+- Test improvements
+- CI/CD changes
+- Any changes that don't warrant a version bump
+
+### Manual Releases
+
+For manual releases or when the automated workflow isn't suitable, you can:
+1. Create a branch with the appropriate prefix (e.g., `patch/manual-release`)
+2. Make your changes
+3. Create a pull request
+4. Merge to trigger the release
 
 ## License
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,16 +1,5 @@
 import Config
 
-config :git_ops,
-  mix_project: Mix.Project.get!(),
-  changelog_file: "CHANGELOG.md",
-  github_token: System.get_env("GITHUB_TOKEN"),
-  types: [tidbit: [hidden?: true], important: [header: "Important Changes"]],
-  github_handle_lookup?: true,
-  repository_url: "https://github.com/daytonn/ecto_cooler",
-  version_tag_prefix: "v",
-  manage_mix_version?: true,
-  manage_readme_version: true
-
 config :ecto_cooler, env: config_env()
 
 import_config "#{config_env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,6 +2,8 @@ import Config
 
 config :git_ops,
   mix_project: Mix.Project.get!(),
+  changelog_file: "CHANGELOG.md",
+  github_token: System.get_env("GITHUB_TOKEN"),
   types: [tidbit: [hidden?: true], important: [header: "Important Changes"]],
   github_handle_lookup?: true,
   repository_url: "https://github.com/daytonn/ecto_cooler",


### PR DESCRIPTION
## Refactor Release Workflow: Remove `git_ops`, Use Branch Name for Versioning

### Overview

This PR modernizes the release automation by **removing the dependency on `git_ops`** and introducing a new, branch-name-driven release workflow. The new approach leverages branch naming conventions to determine the type of version bump (major, minor, patch) and automates changelog and version updates accordingly.

---

### Key Changes

- **Release Workflow (`.github/workflows/release.yml`):**
  - Removed all usage of `git_ops`.
  - Added a step to determine the version bump type based on the branch name (supports `major/`, `breaking/`, `minor/`, `feature/`, `patch/`, `fix/`, `bugfix/`, `hotfix/` prefixes).
  - Added a step to run a custom script (`scripts/bump_version.sh`) that:
    - Bumps the version in `mix.exs`.
    - Updates `CHANGELOG.md` with a new version entry and PR title.
  - Commits and tags the release, then pushes to `main`.
  - Skips the release if the branch name does not match a recognized prefix.
- **Documentation (`README.md`):**
  - Added a new section, **Release Workflow**, documenting:
    - Supported branch naming conventions.
    - What happens on merge.
    - How to skip or trigger releases.
    - Manual release instructions.
- **Configuration (`config/config.exs`):**
  - Removed all `git_ops` configuration.

---

### Why?

- **Simplicity:** Removes the need for an extra dependency and configuration.
- **Transparency:** Release logic is now fully visible and controlled via the workflow and script.
- **Flexibility:** Developers can trigger the appropriate version bump by simply naming their branch with the correct prefix.
- **Documentation:** The new process is clearly documented in the README for all contributors.

---

### How the New Release Process Works

- **Trigger:** When a PR is merged to `main` and the branch name starts with a recognized prefix.
- **Actions:**
  1. Version is bumped according to the prefix.
  2. Changelog is updated with a new version entry and the PR title.
  3. Changes are committed, tagged, and pushed to `main`.
- **No recognized prefix:** The release is skipped (useful for docs, CI, or non-release changes).

---

**Example branch names:**
- `major/breaking-api-change`
- `feature/add-cool-thing`
- `fix/typo-in-readme`
- `patch/hotfix-urgent-bug`

---